### PR TITLE
Add live announcement for date selection and keyboard navigation

### DIFF
--- a/projects/chronica/src/lib/components/date-range/date-range.component.html
+++ b/projects/chronica/src/lib/components/date-range/date-range.component.html
@@ -1,3 +1,4 @@
+<div aria-live="polite" aria-atomic="true" class="chronica-sr-only">{{ liveAnnouncement }}</div>
 <div class="chronica-input-container" [class]="themeClass + ' ' + colorThemeClass">
   <!-- Trigger element for popup mode -->
   <div
@@ -163,6 +164,8 @@
           (mouseenter)="!isDayDisabled(day) && onDateHover(day)"
           (keydown.enter)="selectDate(day)"
           (keydown.space)="selectDate(day)"
+          (keydown)="onDayKeydown($event, day)"
+          [attr.data-day]="day"
           [tabindex]="isDayDisabled(day) ? -1 : 0"
           role="button"
           [attr.aria-label]="

--- a/projects/chronica/src/lib/components/date-range/date-range.component.ts
+++ b/projects/chronica/src/lib/components/date-range/date-range.component.ts
@@ -75,6 +75,8 @@ export class ChronicaDateRangeComponent
   isPopupOpen = false;
   private overlayRef: OverlayRef | null = null;
   private destroy$ = new Subject<void>();
+  focusedDay: number | null = null;
+  liveAnnouncement = '';
 
   // Date range state
   private _dateRange: ChronicaDateRange = { startDate: null, endDate: null };
@@ -174,6 +176,44 @@ export class ChronicaDateRangeComponent
     return Array.from({ length: offset }, (_, i) => i);
   }
 
+  onDayKeydown(event: KeyboardEvent, day: number): void {
+    const navKeys = ['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown', 'PageUp', 'PageDown', 'Home', 'End'];
+    if (!navKeys.includes(event.key)) return;
+    event.preventDefault();
+
+    const date = new Date(this.currentMonth.year, this.currentMonth.month, day);
+    const weekStartsOn = this.getCurrentLocale().weekStartsOn;
+
+    switch (event.key) {
+      case 'ArrowLeft': date.setDate(date.getDate() - 1); break;
+      case 'ArrowRight': date.setDate(date.getDate() + 1); break;
+      case 'ArrowUp': date.setDate(date.getDate() - 7); break;
+      case 'ArrowDown': date.setDate(date.getDate() + 7); break;
+      case 'PageUp': date.setMonth(date.getMonth() - 1); break;
+      case 'PageDown': date.setMonth(date.getMonth() + 1); break;
+      case 'Home': { const dow = (date.getDay() - weekStartsOn + 7) % 7; date.setDate(date.getDate() - dow); break; }
+      case 'End': { const dow = (date.getDay() - weekStartsOn + 7) % 7; date.setDate(date.getDate() + (6 - dow)); break; }
+    }
+    this.navigateToDay(date);
+  }
+
+  private navigateToDay(date: Date): void {
+    const targetYear = date.getFullYear();
+    const targetMonth = date.getMonth();
+    const targetDay = date.getDate();
+    if (targetYear !== this.currentMonth.year || targetMonth !== this.currentMonth.month) {
+      this.generateMonth(targetYear, targetMonth);
+      this.cdr.markForCheck();
+    }
+    this.focusedDay = targetDay;
+    const locale = this.getCurrentLocale();
+    this.liveAnnouncement = `${date.toLocaleDateString('en-US', { weekday: 'long' })}, ${locale.monthNames[targetMonth]} ${targetDay}, ${targetYear}`;
+    setTimeout(() => {
+      const container = this.overlayRef?.overlayElement ?? this.elementRef.nativeElement;
+      (container.querySelector(`[data-day="${targetDay}"]`) as HTMLElement | null)?.focus();
+    });
+  }
+
   previousMonth(): void {
     if (this.isPreviousMonthDisabled()) return;
 
@@ -255,6 +295,8 @@ export class ChronicaDateRangeComponent
       this.closePopup();
     }
 
+    const locale = this.getCurrentLocale();
+    this.liveAnnouncement = `${selectedDate.toLocaleDateString('en-US', { weekday: 'long' })}, ${locale.monthNames[selectedDate.getMonth()]} ${day}, ${selectedDate.getFullYear()} selected`;
     this.onChange(this._dateRange);
     this.dateRangeChange.emit(this._dateRange);
     this.calendarEvent.emit({

--- a/projects/chronica/src/lib/components/datepicker/datepicker.component.html
+++ b/projects/chronica/src/lib/components/datepicker/datepicker.component.html
@@ -1,3 +1,4 @@
+<div aria-live="polite" aria-atomic="true" class="chronica-sr-only">{{ liveAnnouncement }}</div>
 <div class="chronica-input-container" [class]="themeClass + ' ' + colorThemeClass">
   <!-- Default input element -->
   @if (!hideInput) {
@@ -165,8 +166,10 @@
             (click)="selectDate(day)"
             (keydown.enter)="selectDate(day)"
             (keydown.space)="selectDate(day)"
+            (keydown)="onDayKeydown($event, day)"
             tabindex="0"
             role="gridcell"
+            [attr.data-day]="day"
             [attr.aria-label]="getDateLabel(day)"
             [attr.aria-selected]="isSelectedDate(day)"
             [attr.aria-disabled]="isDateDisabled(day)"

--- a/projects/chronica/src/lib/components/datepicker/datepicker.component.ts
+++ b/projects/chronica/src/lib/components/datepicker/datepicker.component.ts
@@ -74,6 +74,8 @@ export class ChronicaDatepickerComponent
   isPopupOpen = false;
   private overlayRef: OverlayRef | null = null;
   private destroy$ = new Subject<void>();
+  focusedDay: number | null = null;
+  liveAnnouncement = '';
 
   @ViewChild('calendarTemplate', { static: true }) calendarTemplate!: TemplateRef<any>;
 
@@ -177,6 +179,7 @@ export class ChronicaDatepickerComponent
       timestamp: Date.now(),
     });
 
+    this.liveAnnouncement = `${this.getDateLabel(validDay)} selected`;
     // Close popup after date selection
     this.closePopup();
   }
@@ -319,6 +322,43 @@ export class ChronicaDatepickerComponent
     const dayName = date.toLocaleDateString('en-US', { weekday: 'long' });
     const monthName = locale.monthNames[date.getMonth()];
     return `${dayName}, ${monthName} ${day}, ${date.getFullYear()}`;
+  }
+
+  onDayKeydown(event: KeyboardEvent, day: number): void {
+    const navKeys = ['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown', 'PageUp', 'PageDown', 'Home', 'End'];
+    if (!navKeys.includes(event.key)) return;
+    event.preventDefault();
+
+    const date = new Date(this.currentMonth.year, this.currentMonth.month, day);
+    const weekStartsOn = this.getCurrentLocale().weekStartsOn;
+
+    switch (event.key) {
+      case 'ArrowLeft': date.setDate(date.getDate() - 1); break;
+      case 'ArrowRight': date.setDate(date.getDate() + 1); break;
+      case 'ArrowUp': date.setDate(date.getDate() - 7); break;
+      case 'ArrowDown': date.setDate(date.getDate() + 7); break;
+      case 'PageUp': date.setMonth(date.getMonth() - 1); break;
+      case 'PageDown': date.setMonth(date.getMonth() + 1); break;
+      case 'Home': { const dow = (date.getDay() - weekStartsOn + 7) % 7; date.setDate(date.getDate() - dow); break; }
+      case 'End': { const dow = (date.getDay() - weekStartsOn + 7) % 7; date.setDate(date.getDate() + (6 - dow)); break; }
+    }
+    this.navigateToDay(date);
+  }
+
+  private navigateToDay(date: Date): void {
+    const targetYear = date.getFullYear();
+    const targetMonth = date.getMonth();
+    const targetDay = date.getDate();
+    if (targetYear !== this.currentMonth.year || targetMonth !== this.currentMonth.month) {
+      this.generateMonth(targetYear, targetMonth);
+      this.cdr.markForCheck();
+    }
+    this.focusedDay = targetDay;
+    this.liveAnnouncement = this.getDateLabel(targetDay);
+    setTimeout(() => {
+      const container = this.overlayRef?.overlayElement ?? this.elementRef.nativeElement;
+      (container.querySelector(`[data-day="${targetDay}"]`) as HTMLElement | null)?.focus();
+    });
   }
 
   previousMonth(): void {

--- a/projects/chronica/src/lib/components/datetime-picker/datetime-picker.component.html
+++ b/projects/chronica/src/lib/components/datetime-picker/datetime-picker.component.html
@@ -1,3 +1,4 @@
+<div aria-live="polite" aria-atomic="true" class="chronica-sr-only">{{ liveAnnouncement }}</div>
 <div class="chronica-input-container" [class]="themeClass + ' ' + colorThemeClass">
   <!-- DateTime Input Trigger (single combined input) -->
   @if (!hideInput && !config.showSeparateInputs) {
@@ -249,9 +250,13 @@
                   (click)="selectDate(day)"
                   (keydown.enter)="selectDate(day)"
                   (keydown.space)="selectDate(day)"
+                  (keydown)="onDayKeydown($event, day)"
                   tabindex="0"
-                  role="button"
+                  role="gridcell"
+                  [attr.data-day]="day"
                   [attr.aria-label]="'Select date ' + day"
+                  [attr.aria-selected]="isSelectedDate(day)"
+                  [attr.aria-disabled]="isDateDisabled(day)"
                 >
                   {{ day }}
                 </div>
@@ -423,8 +428,10 @@
                   (click)="selectDate(day)"
                   (keydown.enter)="selectDate(day)"
                   (keydown.space)="selectDate(day)"
+                  (keydown)="onDayKeydown($event, day)"
                   tabindex="0"
                   role="gridcell"
+                  [attr.data-day]="day"
                   [attr.aria-label]="'Select date ' + day"
                   [attr.aria-selected]="isSelectedDate(day)"
                   [attr.aria-disabled]="isDateDisabled(day)"

--- a/projects/chronica/src/lib/components/datetime-picker/datetime-picker.component.ts
+++ b/projects/chronica/src/lib/components/datetime-picker/datetime-picker.component.ts
@@ -82,6 +82,8 @@ export class ChronicaDateTimePickerComponent
   dayNames: string[] = [];
   monthNames: string[] = [];
   yearRange: number[] = [];
+  focusedDay: number | null = null;
+  liveAnnouncement = '';
 
   // Time selection state
   selectedHour = 0;
@@ -295,6 +297,8 @@ export class ChronicaDateTimePickerComponent
     const selectedDate = new Date(this.currentMonth.year, this.currentMonth.month, day);
     this._value.date = selectedDate;
 
+    const locale = this.getCurrentLocale();
+    this.liveAnnouncement = `${selectedDate.toLocaleDateString('en-US', { weekday: 'long' })}, ${locale.monthNames[selectedDate.getMonth()]} ${day}, ${selectedDate.getFullYear()} selected`;
     this.dateSelected.emit(new Date(selectedDate));
     this.updateValue();
   }
@@ -347,6 +351,42 @@ export class ChronicaDateTimePickerComponent
     }
 
     return false;
+  }
+
+  onDayKeydown(event: KeyboardEvent, day: number): void {
+    const navKeys = ['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown', 'PageUp', 'PageDown', 'Home', 'End'];
+    if (!navKeys.includes(event.key)) return;
+    event.preventDefault();
+
+    const date = new Date(this.currentMonth.year, this.currentMonth.month, day);
+    const weekStartsOn = this.getCurrentLocale().weekStartsOn;
+
+    switch (event.key) {
+      case 'ArrowLeft': date.setDate(date.getDate() - 1); break;
+      case 'ArrowRight': date.setDate(date.getDate() + 1); break;
+      case 'ArrowUp': date.setDate(date.getDate() - 7); break;
+      case 'ArrowDown': date.setDate(date.getDate() + 7); break;
+      case 'PageUp': date.setMonth(date.getMonth() - 1); break;
+      case 'PageDown': date.setMonth(date.getMonth() + 1); break;
+      case 'Home': { const dow = (date.getDay() - weekStartsOn + 7) % 7; date.setDate(date.getDate() - dow); break; }
+      case 'End': { const dow = (date.getDay() - weekStartsOn + 7) % 7; date.setDate(date.getDate() + (6 - dow)); break; }
+    }
+
+    const targetYear = date.getFullYear();
+    const targetMonth = date.getMonth();
+    const targetDay = date.getDate();
+    if (targetYear !== this.currentMonth.year || targetMonth !== this.currentMonth.month) {
+      this.currentMonth = { year: targetYear, month: targetMonth };
+      this.yearRange = ChronicaCalendarUtils.updateYearRange(targetYear);
+      this.cdr.markForCheck();
+    }
+    this.focusedDay = targetDay;
+    const locale = this.getCurrentLocale();
+    this.liveAnnouncement = `${date.toLocaleDateString('en-US', { weekday: 'long' })}, ${locale.monthNames[targetMonth]} ${targetDay}, ${targetYear}`;
+    setTimeout(() => {
+      const container = this.overlayRef?.overlayElement ?? this.elementRef.nativeElement;
+      (container.querySelector(`[data-day="${targetDay}"]`) as HTMLElement | null)?.focus();
+    });
   }
 
   previousMonth(): void {

--- a/projects/chronica/src/lib/components/inline-calendar/inline-calendar.component.html
+++ b/projects/chronica/src/lib/components/inline-calendar/inline-calendar.component.html
@@ -1,3 +1,4 @@
+<div aria-live="polite" aria-atomic="true" class="chronica-sr-only">{{ liveAnnouncement }}</div>
 <div class="chronica-inline-calendar" [class]="colorThemeClass + ' ' + themeClass">
   <div class="chronica-calendar-body">
     <!-- Calendar Header -->
@@ -82,7 +83,9 @@
               [attr.aria-label]="date.date | date: 'MMMM d, yyyy'"
               [attr.aria-selected]="date.selected"
               [attr.aria-disabled]="date.disabled"
+              [attr.data-date]="date.date.getFullYear() + '-' + date.date.getMonth() + '-' + date.date.getDate()"
               (click)="selectDate(date)"
+              (keydown)="onDayKeydown($event, date.date)"
             >
               {{ date.date.getDate() }}
             </button>

--- a/projects/chronica/src/lib/components/inline-calendar/inline-calendar.component.ts
+++ b/projects/chronica/src/lib/components/inline-calendar/inline-calendar.component.ts
@@ -10,6 +10,7 @@ import {
   forwardRef,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
+  ElementRef,
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule, ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
@@ -62,8 +63,9 @@ export class ChronicaInlineCalendarComponent implements OnInit, OnChanges, OnDes
   yearRange: number[] = [];
   currentView: ChronicaCalendarView = 'month';
   yearGridYears: number[] = [];
+  liveAnnouncement = '';
 
-  constructor(private cdr: ChangeDetectorRef) {
+  constructor(private cdr: ChangeDetectorRef, private elementRef: ElementRef) {
     this.yearRange = ChronicaCalendarUtils.updateYearRange(new Date().getFullYear());
   }
 
@@ -122,6 +124,8 @@ export class ChronicaInlineCalendarComponent implements OnInit, OnChanges, OnDes
       timestamp: Date.now(),
     });
 
+    const locale = this.getCurrentLocale();
+    this.liveAnnouncement = `${date.date.toLocaleDateString('en-US', { weekday: 'long' })}, ${locale.monthNames[date.date.getMonth()]} ${date.date.getDate()}, ${date.date.getFullYear()} selected`;
     this.updateSelectedDate();
   }
 
@@ -172,6 +176,44 @@ export class ChronicaInlineCalendarComponent implements OnInit, OnChanges, OnDes
       type: 'monthChange',
       payload: { month: next.month, year: next.year },
       timestamp: Date.now(),
+    });
+  }
+
+  onDayKeydown(event: KeyboardEvent, date: Date): void {
+    const navKeys = ['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown', 'PageUp', 'PageDown', 'Home', 'End'];
+    if (!navKeys.includes(event.key)) return;
+    event.preventDefault();
+
+    const target = new Date(date);
+    const weekStartsOn = this.getCurrentLocale().weekStartsOn;
+
+    switch (event.key) {
+      case 'ArrowLeft': target.setDate(target.getDate() - 1); break;
+      case 'ArrowRight': target.setDate(target.getDate() + 1); break;
+      case 'ArrowUp': target.setDate(target.getDate() - 7); break;
+      case 'ArrowDown': target.setDate(target.getDate() + 7); break;
+      case 'PageUp': target.setMonth(target.getMonth() - 1); break;
+      case 'PageDown': target.setMonth(target.getMonth() + 1); break;
+      case 'Home': { const dow = (target.getDay() - weekStartsOn + 7) % 7; target.setDate(target.getDate() - dow); break; }
+      case 'End': { const dow = (target.getDay() - weekStartsOn + 7) % 7; target.setDate(target.getDate() + (6 - dow)); break; }
+    }
+    this.navigateToDay(target);
+  }
+
+  private navigateToDay(date: Date): void {
+    if (date.getMonth() !== this.currentMonth.month || date.getFullYear() !== this.currentMonth.year) {
+      this.yearRange = ChronicaCalendarUtils.updateYearRange(date.getFullYear());
+      this.currentMonth = ChronicaCalendarUtils.generateCalendarMonth(
+        date.getFullYear(), date.getMonth(), this.getLocaleConfig()
+      );
+      if (this.selectedDate) this.updateSelectedDate();
+      this.cdr.markForCheck();
+    }
+    const locale = this.getCurrentLocale();
+    this.liveAnnouncement = `${date.toLocaleDateString('en-US', { weekday: 'long' })}, ${locale.monthNames[date.getMonth()]} ${date.getDate()}, ${date.getFullYear()}`;
+    const key = `${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`;
+    setTimeout(() => {
+      (this.elementRef.nativeElement.querySelector(`[data-date="${key}"]`) as HTMLElement | null)?.focus();
     });
   }
 

--- a/projects/chronica/src/styles/styles.css
+++ b/projects/chronica/src/styles/styles.css
@@ -91,3 +91,14 @@
   padding: 16px 20px;
   border-top: var(--chronica-border-width, 1px) solid var(--chronica-border-color, #e5e7eb);
 }
+.chronica-sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}


### PR DESCRIPTION
P1-3 — Keyboard arrow navigation (WCAG 2.1 SC 2.1.1):

datepicker, date-range, datetime-picker: Added onDayKeydown(event, day) + navigateToDay(date) with [attr.data-day] for focus targeting via overlayRef.overlayElement
inline-calendar: Same pattern but uses full Date objects with [attr.data-date]="Y-M-D" key, and ElementRef (newly injected) for DOM querying
Supports: ←→↑↓ (±1/7 days), PageUp/Down (±1 month), Home/End (row start/end respecting locale's weekStartsOn)
P1-4 — aria-live regions:

Added liveAnnouncement property to all 4 components
Announces focused date on navigation, and "X selected" on date pick
<div aria-live="polite" aria-atomic="true" class="chronica-sr-only"> placed before each component's root element
chronica-sr-only utility class added to shared styles.css