### PR TITLE
P1-6: Unit Test Suite

### DIFF
--- a/projects/chronica/src/lib/components/datepicker/datepicker.component.spec.ts
+++ b/projects/chronica/src/lib/components/datepicker/datepicker.component.spec.ts
@@ -1,0 +1,189 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Component } from '@angular/core';
+import { ReactiveFormsModule, FormControl } from '@angular/forms';
+import { OverlayModule } from '@angular/cdk/overlay';
+import { ChronicaDatepickerComponent } from './datepicker.component';
+import { CHRONICA_LOCALES } from '../../models';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+const d = (y: number, m: number, day: number) => new Date(y, m, day);
+
+@Component({
+  standalone: true,
+  imports: [ChronicaDatepickerComponent, ReactiveFormsModule],
+  template: `<chronica-datepicker [formControl]="ctrl"></chronica-datepicker>`,
+})
+class TestHostComponent {
+  ctrl = new FormControl<Date | null>(null);
+}
+
+// ─── Specs ────────────────────────────────────────────────────────────────────
+describe('ChronicaDatepickerComponent', () => {
+  let fixture: ComponentFixture<ChronicaDatepickerComponent>;
+  let component: ChronicaDatepickerComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ChronicaDatepickerComponent, OverlayModule],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ChronicaDatepickerComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  // ── Creation ────────────────────────────────────────────────────────────────
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('initialises with no selected date', () => {
+    expect(component.selectedDate).toBeNull();
+  });
+
+  // ── ControlValueAccessor ────────────────────────────────────────────────────
+  describe('ControlValueAccessor', () => {
+    it('writeValue sets the selected date', () => {
+      const date = d(2024, 4, 15);
+      component.writeValue(date);
+      expect(component.selectedDate).toEqual(date);
+    });
+
+    it('writeValue with null clears the selection', () => {
+      component.writeValue(d(2024, 4, 15));
+      component.writeValue(null);
+      expect(component.selectedDate).toBeNull();
+    });
+
+    it('setDisabledState disables the component', () => {
+      component.setDisabledState(true);
+      expect(component.disabled).toBeTrue();
+    });
+
+    it('setDisabledState re-enables the component', () => {
+      component.setDisabledState(true);
+      component.setDisabledState(false);
+      expect(component.disabled).toBeFalse();
+    });
+
+    it('registerOnChange stores the callback', () => {
+      const cb = jasmine.createSpy('onChange');
+      component.registerOnChange(cb);
+      component.selectDate(15);
+      expect(cb).toHaveBeenCalled();
+    });
+  });
+
+  // ── Locale ──────────────────────────────────────────────────────────────────
+  describe('getCurrentLocale', () => {
+    it('returns en-US locale by default', () => {
+      const locale = component.getCurrentLocale();
+      expect(locale.monthNames[0]).toBe('January');
+    });
+
+    it('returns the locale object when passed directly', () => {
+      component.locale = CHRONICA_LOCALES['de-DE'];
+      expect(component.getCurrentLocale().monthNames[0]).toBe('Januar');
+    });
+
+    it('resolves a locale string to the correct config', () => {
+      component.locale = 'fr-FR';
+      expect(component.getCurrentLocale().monthNames[0]).toBe('Janvier');
+    });
+
+    it('falls back to en-US for unknown locale string', () => {
+      component.locale = 'xx-XX';
+      expect(component.getCurrentLocale().monthNames[0]).toBe('January');
+    });
+  });
+
+  // ── Calendar helpers ────────────────────────────────────────────────────────
+  describe('getDaysInMonth', () => {
+    it('returns 31 days for May', () => {
+      component.writeValue(d(2024, 4, 1));
+      fixture.detectChanges();
+      expect(component.getDaysInMonth().length).toBe(31);
+    });
+
+    it('returns 29 days for February 2024 (leap year)', () => {
+      component.initialMonth = 1;
+      component.initialYear = 2024;
+      component.ngOnInit();
+      fixture.detectChanges();
+      expect(component.getDaysInMonth().length).toBe(29);
+    });
+  });
+
+  describe('isToday', () => {
+    it('returns true for today\'s day number in the current month', () => {
+      const today = new Date();
+      component.writeValue(today);
+      fixture.detectChanges();
+      expect(component.isToday(today.getDate())).toBeTrue();
+    });
+  });
+
+  describe('isSelectedDate', () => {
+    it('returns true for the day of the selected date', () => {
+      // Use today so currentMonth year/month match
+      const today = new Date();
+      component.writeValue(today);
+      fixture.detectChanges();
+      expect(component.isSelectedDate(today.getDate())).toBeTrue();
+    });
+
+    it('returns false for a different day', () => {
+      const today = new Date();
+      component.writeValue(today);
+      fixture.detectChanges();
+      // Pick a day that definitely differs (today ± 1, clamped to valid range)
+      const other = today.getDate() === 1 ? 2 : today.getDate() - 1;
+      expect(component.isSelectedDate(other)).toBeFalse();
+    });
+  });
+
+  // ── Event output ────────────────────────────────────────────────────────────
+  describe('dateSelected output', () => {
+    it('emits the selected date when selectDate is called', () => {
+      const emitted: Date[] = [];
+      component.dateSelected.subscribe((d: Date) => emitted.push(d));
+      component.writeValue(d(2024, 4, 1));
+      fixture.detectChanges();
+      component.selectDate(15);
+      expect(emitted.length).toBe(1);
+      expect(emitted[0].getDate()).toBe(15);
+    });
+  });
+});
+
+// ─── FormControl integration ──────────────────────────────────────────────────
+describe('ChronicaDatepickerComponent (reactive form)', () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+  let host: TestHostComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent, OverlayModule],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    host = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('patches the form control value', () => {
+    const date = d(2024, 4, 15);
+    host.ctrl.setValue(date);
+    fixture.detectChanges();
+    expect(host.ctrl.value).toEqual(date);
+  });
+
+  it('disabling the form control disables the component', () => {
+    host.ctrl.disable();
+    fixture.detectChanges();
+    const picker = fixture.debugElement.query(
+      (el) => el.componentInstance instanceof ChronicaDatepickerComponent
+    )?.componentInstance as ChronicaDatepickerComponent;
+    expect(picker?.disabled).toBeTrue();
+  });
+});

--- a/projects/chronica/src/lib/components/inline-calendar/inline-calendar.component.spec.ts
+++ b/projects/chronica/src/lib/components/inline-calendar/inline-calendar.component.spec.ts
@@ -1,0 +1,218 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Component } from '@angular/core';
+import { ReactiveFormsModule, FormControl } from '@angular/forms';
+import { ChronicaInlineCalendarComponent } from './inline-calendar.component';
+import { CHRONICA_LOCALES } from '../../models';
+
+const d = (y: number, m: number, day: number) => new Date(y, m, day);
+
+@Component({
+  standalone: true,
+  imports: [ChronicaInlineCalendarComponent, ReactiveFormsModule],
+  template: `<chronica-inline-calendar [formControl]="ctrl"></chronica-inline-calendar>`,
+})
+class TestHostComponent {
+  ctrl = new FormControl<Date | null>(null);
+}
+
+describe('ChronicaInlineCalendarComponent', () => {
+  let fixture: ComponentFixture<ChronicaInlineCalendarComponent>;
+  let component: ChronicaInlineCalendarComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ChronicaInlineCalendarComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ChronicaInlineCalendarComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  // ── Creation ────────────────────────────────────────────────────────────────
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('starts in the month view', () => {
+    expect(component.currentView).toBe('month');
+  });
+
+  it('initialises with no selected date', () => {
+    expect(component.selectedDate).toBeNull();
+  });
+
+  // ── Calendar state ──────────────────────────────────────────────────────────
+  it('currentMonth is set on init', () => {
+    expect(component.currentMonth).toBeDefined();
+    expect(component.currentMonth.weeks.length).toBeGreaterThan(0);
+  });
+
+  it('dayNames has 7 entries', () => {
+    expect(component.dayNames.length).toBe(7);
+  });
+
+  // ── ControlValueAccessor ────────────────────────────────────────────────────
+  describe('ControlValueAccessor', () => {
+    it('writeValue sets selectedDate', () => {
+      const date = d(2024, 4, 15);
+      component.writeValue(date);
+      expect(component.selectedDate).toEqual(date);
+    });
+
+    it('writeValue null clears the selection', () => {
+      component.writeValue(d(2024, 4, 15));
+      component.writeValue(null);
+      expect(component.selectedDate).toBeNull();
+    });
+
+    it('setDisabledState updates disabled flag', () => {
+      component.setDisabledState(true);
+      expect(component.disabled).toBeTrue();
+      component.setDisabledState(false);
+      expect(component.disabled).toBeFalse();
+    });
+
+    it('registerOnChange callback is called on date selection', () => {
+      const cb = jasmine.createSpy('onChange');
+      component.registerOnChange(cb);
+      const dateCell = component.currentMonth.dates.find(
+        (c) => c.inCurrentMonth && !c.disabled
+      );
+      if (dateCell) {
+        component.selectDate(dateCell);
+        expect(cb).toHaveBeenCalledWith(dateCell.date);
+      }
+    });
+  });
+
+  // ── Locale ──────────────────────────────────────────────────────────────────
+  describe('getCurrentLocale', () => {
+    it('returns en-US locale by default', () => {
+      expect(component.getCurrentLocale().monthNames[0]).toBe('January');
+    });
+
+    it('resolves a locale string', () => {
+      component.locale = 'es-ES';
+      expect(component.getCurrentLocale().monthNames[0]).toBe('Enero');
+    });
+
+    it('accepts a locale object directly', () => {
+      component.locale = CHRONICA_LOCALES['ja-JP'];
+      expect(component.getCurrentLocale().monthNames[0]).toBe('1月');
+    });
+
+    it('falls back to en-US for an unknown code', () => {
+      component.locale = 'zz-ZZ';
+      expect(component.getCurrentLocale().monthNames[0]).toBe('January');
+    });
+  });
+
+  // ── Navigation ──────────────────────────────────────────────────────────────
+  describe('previousMonth / nextMonth', () => {
+    it('previousMonth decrements the displayed month', () => {
+      const initial = component.currentMonth.month;
+      component.previousMonth();
+      fixture.detectChanges();
+      const expected = initial === 0 ? 11 : initial - 1;
+      expect(component.currentMonth.month).toBe(expected);
+    });
+
+    it('nextMonth increments the displayed month', () => {
+      const initial = component.currentMonth.month;
+      component.nextMonth();
+      fixture.detectChanges();
+      const expected = initial === 11 ? 0 : initial + 1;
+      expect(component.currentMonth.month).toBe(expected);
+    });
+
+    it('previousMonth wraps year correctly from January', () => {
+      component.initialMonth = 0;
+      component.initialYear = 2024;
+      component.ngOnInit();
+      fixture.detectChanges();
+      component.previousMonth();
+      fixture.detectChanges();
+      expect(component.currentMonth.month).toBe(11);
+      expect(component.currentMonth.year).toBe(2023);
+    });
+
+    it('nextMonth wraps year correctly from December', () => {
+      component.initialMonth = 11;
+      component.initialYear = 2024;
+      component.ngOnInit();
+      fixture.detectChanges();
+      component.nextMonth();
+      fixture.detectChanges();
+      expect(component.currentMonth.month).toBe(0);
+      expect(component.currentMonth.year).toBe(2025);
+    });
+  });
+
+  // ── View switching ───────────────────────────────────────────────────────────
+  describe('cycleView', () => {
+    it('cycles month → months → year → month', () => {
+      expect(component.currentView).toBe('month');
+      component.cycleView();
+      expect(component.currentView).toBe('months');
+      component.cycleView();
+      expect(component.currentView).toBe('year');
+      component.cycleView();
+      expect(component.currentView).toBe('month');
+    });
+  });
+
+  // ── Date selection output ───────────────────────────────────────────────────
+  describe('dateSelected output', () => {
+    it('emits a Date when a cell is selected', () => {
+      const emitted: Date[] = [];
+      component.dateSelected.subscribe((d: Date) => emitted.push(d));
+      const cell = component.currentMonth.dates.find((c) => c.inCurrentMonth && !c.disabled);
+      if (cell) {
+        component.selectDate(cell);
+        expect(emitted.length).toBe(1);
+        expect(emitted[0]).toEqual(cell.date);
+      }
+    });
+
+    it('does not emit for a disabled cell', () => {
+      const emitted: Date[] = [];
+      component.dateSelected.subscribe((d: Date) => emitted.push(d));
+      const disabledCell = { ...component.currentMonth.dates[0], disabled: true };
+      component.selectDate(disabledCell);
+      expect(emitted.length).toBe(0);
+    });
+  });
+});
+
+// ─── FormControl integration ──────────────────────────────────────────────────
+describe('ChronicaInlineCalendarComponent (reactive form)', () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+  let host: TestHostComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    host = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('sets an initial value via the form control', () => {
+    const date = d(2024, 4, 15);
+    host.ctrl.setValue(date);
+    fixture.detectChanges();
+    expect(host.ctrl.value).toEqual(date);
+  });
+
+  it('disabling the form control disables the calendar', () => {
+    host.ctrl.disable();
+    fixture.detectChanges();
+    const cal = fixture.debugElement.query(
+      (el) => el.componentInstance instanceof ChronicaInlineCalendarComponent
+    )?.componentInstance as ChronicaInlineCalendarComponent;
+    expect(cal?.disabled).toBeTrue();
+  });
+});

--- a/projects/chronica/src/lib/utils/calendar.utils.spec.ts
+++ b/projects/chronica/src/lib/utils/calendar.utils.spec.ts
@@ -1,0 +1,314 @@
+import { ChronicaCalendarUtils } from './calendar.utils';
+import { CHRONICA_LOCALES } from '../models';
+
+describe('ChronicaCalendarUtils', () => {
+  const d = (y: number, m: number, day: number) => new Date(y, m, day);
+
+  // ─── isSameDate ────────────────────────────────────────────────────────────
+  describe('isSameDate', () => {
+    it('returns true for identical dates', () => {
+      expect(ChronicaCalendarUtils.isSameDate(d(2024, 4, 15), d(2024, 4, 15))).toBeTrue();
+    });
+    it('ignores time component', () => {
+      const a = new Date(2024, 4, 15, 10, 30);
+      const b = new Date(2024, 4, 15, 22, 0);
+      expect(ChronicaCalendarUtils.isSameDate(a, b)).toBeTrue();
+    });
+    it('returns false for different day', () => {
+      expect(ChronicaCalendarUtils.isSameDate(d(2024, 4, 15), d(2024, 4, 16))).toBeFalse();
+    });
+    it('returns false for different month', () => {
+      expect(ChronicaCalendarUtils.isSameDate(d(2024, 4, 15), d(2024, 5, 15))).toBeFalse();
+    });
+    it('returns false for different year', () => {
+      expect(ChronicaCalendarUtils.isSameDate(d(2024, 4, 15), d(2025, 4, 15))).toBeFalse();
+    });
+  });
+
+  // ─── isToday ───────────────────────────────────────────────────────────────
+  describe('isToday', () => {
+    it('returns true for today', () => {
+      expect(ChronicaCalendarUtils.isToday(new Date())).toBeTrue();
+    });
+    it('returns false for yesterday', () => {
+      const yesterday = new Date();
+      yesterday.setDate(yesterday.getDate() - 1);
+      expect(ChronicaCalendarUtils.isToday(yesterday)).toBeFalse();
+    });
+    it('returns false for tomorrow', () => {
+      const tomorrow = new Date();
+      tomorrow.setDate(tomorrow.getDate() + 1);
+      expect(ChronicaCalendarUtils.isToday(tomorrow)).toBeFalse();
+    });
+  });
+
+  // ─── isWeekend ─────────────────────────────────────────────────────────────
+  describe('isWeekend', () => {
+    it('returns true for Sunday', () => {
+      expect(ChronicaCalendarUtils.isWeekend(new Date(2024, 4, 5))).toBeTrue(); // Sun May 5 2024
+    });
+    it('returns true for Saturday', () => {
+      expect(ChronicaCalendarUtils.isWeekend(new Date(2024, 4, 4))).toBeTrue(); // Sat May 4 2024
+    });
+    it('returns false for Monday', () => {
+      expect(ChronicaCalendarUtils.isWeekend(new Date(2024, 4, 6))).toBeFalse(); // Mon May 6 2024
+    });
+    it('returns false for Friday', () => {
+      expect(ChronicaCalendarUtils.isWeekend(new Date(2024, 4, 10))).toBeFalse(); // Fri May 10 2024
+    });
+  });
+
+  // ─── getFirstDayOfMonth ────────────────────────────────────────────────────
+  describe('getFirstDayOfMonth', () => {
+    it('returns day 1 of the same month/year', () => {
+      const result = ChronicaCalendarUtils.getFirstDayOfMonth(d(2024, 4, 15));
+      expect(result.getDate()).toBe(1);
+      expect(result.getMonth()).toBe(4);
+      expect(result.getFullYear()).toBe(2024);
+    });
+    it('returns day 1 when given the last day', () => {
+      const result = ChronicaCalendarUtils.getFirstDayOfMonth(d(2024, 4, 31));
+      expect(result.getDate()).toBe(1);
+    });
+  });
+
+  // ─── getLastDayOfMonth ─────────────────────────────────────────────────────
+  describe('getLastDayOfMonth', () => {
+    it('returns 31 for May', () => {
+      expect(ChronicaCalendarUtils.getLastDayOfMonth(d(2024, 4, 1)).getDate()).toBe(31);
+    });
+    it('returns 30 for April', () => {
+      expect(ChronicaCalendarUtils.getLastDayOfMonth(d(2024, 3, 1)).getDate()).toBe(30);
+    });
+    it('returns 29 for February in a leap year', () => {
+      expect(ChronicaCalendarUtils.getLastDayOfMonth(d(2024, 1, 1)).getDate()).toBe(29);
+    });
+    it('returns 28 for February in a non-leap year', () => {
+      expect(ChronicaCalendarUtils.getLastDayOfMonth(d(2023, 1, 1)).getDate()).toBe(28);
+    });
+  });
+
+  // ─── addMonths ─────────────────────────────────────────────────────────────
+  describe('addMonths', () => {
+    it('adds months within the same year', () => {
+      const result = ChronicaCalendarUtils.addMonths(d(2024, 0, 15), 2);
+      expect(result.getMonth()).toBe(2);
+      expect(result.getFullYear()).toBe(2024);
+    });
+    it('wraps to next year when crossing December', () => {
+      const result = ChronicaCalendarUtils.addMonths(d(2024, 11, 15), 1);
+      expect(result.getMonth()).toBe(0);
+      expect(result.getFullYear()).toBe(2025);
+    });
+    it('subtracts months with negative value', () => {
+      const result = ChronicaCalendarUtils.addMonths(d(2024, 2, 15), -2);
+      expect(result.getMonth()).toBe(0);
+    });
+    it('does not mutate the original date', () => {
+      const original = d(2024, 0, 15);
+      ChronicaCalendarUtils.addMonths(original, 3);
+      expect(original.getMonth()).toBe(0);
+    });
+  });
+
+  // ─── addDays ───────────────────────────────────────────────────────────────
+  describe('addDays', () => {
+    it('adds days within the same month', () => {
+      const result = ChronicaCalendarUtils.addDays(d(2024, 4, 15), 5);
+      expect(result.getDate()).toBe(20);
+      expect(result.getMonth()).toBe(4);
+    });
+    it('wraps to next month', () => {
+      const result = ChronicaCalendarUtils.addDays(d(2024, 4, 30), 3);
+      expect(result.getDate()).toBe(2);
+      expect(result.getMonth()).toBe(5);
+    });
+    it('subtracts days with negative value', () => {
+      const result = ChronicaCalendarUtils.addDays(d(2024, 4, 5), -4);
+      expect(result.getDate()).toBe(1);
+    });
+    it('does not mutate the original date', () => {
+      const original = d(2024, 4, 15);
+      ChronicaCalendarUtils.addDays(original, 5);
+      expect(original.getDate()).toBe(15);
+    });
+  });
+
+  // ─── stripTime ─────────────────────────────────────────────────────────────
+  describe('stripTime', () => {
+    it('sets hours, minutes, seconds, ms to zero', () => {
+      const withTime = new Date(2024, 4, 15, 10, 30, 45, 999);
+      const stripped = ChronicaCalendarUtils.stripTime(withTime);
+      expect(stripped.getHours()).toBe(0);
+      expect(stripped.getMinutes()).toBe(0);
+      expect(stripped.getSeconds()).toBe(0);
+      expect(stripped.getMilliseconds()).toBe(0);
+    });
+    it('preserves the date part', () => {
+      const date = new Date(2024, 4, 15, 23, 59, 59);
+      const stripped = ChronicaCalendarUtils.stripTime(date);
+      expect(stripped.getFullYear()).toBe(2024);
+      expect(stripped.getMonth()).toBe(4);
+      expect(stripped.getDate()).toBe(15);
+    });
+  });
+
+  // ─── formatDate ────────────────────────────────────────────────────────────
+  describe('formatDate', () => {
+    it('formats en-US as MM/dd/yyyy', () => {
+      const locale = CHRONICA_LOCALES['en-US'];
+      expect(ChronicaCalendarUtils.formatDate(d(2024, 4, 5), locale)).toBe('05/05/2024');
+    });
+    it('formats de-DE as dd.MM.yyyy', () => {
+      const locale = CHRONICA_LOCALES['de-DE'];
+      expect(ChronicaCalendarUtils.formatDate(d(2024, 4, 5), locale)).toBe('05.05.2024');
+    });
+    it('formats ja-JP as yyyy/MM/dd', () => {
+      const locale = CHRONICA_LOCALES['ja-JP'];
+      expect(ChronicaCalendarUtils.formatDate(d(2024, 4, 5), locale)).toBe('2024/05/05');
+    });
+    it('zero-pads single-digit day and month', () => {
+      const locale = CHRONICA_LOCALES['en-US'];
+      expect(ChronicaCalendarUtils.formatDate(d(2024, 0, 3), locale)).toBe('01/03/2024');
+    });
+  });
+
+  // ─── getPreviousMonth ──────────────────────────────────────────────────────
+  describe('getPreviousMonth', () => {
+    it('returns the previous month in the same year', () => {
+      expect(ChronicaCalendarUtils.getPreviousMonth(5, 2024)).toEqual({ month: 4, year: 2024 });
+    });
+    it('wraps from January to December of the previous year', () => {
+      expect(ChronicaCalendarUtils.getPreviousMonth(0, 2024)).toEqual({ month: 11, year: 2023 });
+    });
+  });
+
+  // ─── getNextMonth ──────────────────────────────────────────────────────────
+  describe('getNextMonth', () => {
+    it('returns the next month in the same year', () => {
+      expect(ChronicaCalendarUtils.getNextMonth(5, 2024)).toEqual({ month: 6, year: 2024 });
+    });
+    it('wraps from December to January of the next year', () => {
+      expect(ChronicaCalendarUtils.getNextMonth(11, 2024)).toEqual({ month: 0, year: 2025 });
+    });
+  });
+
+  // ─── generateDecadeGrid ────────────────────────────────────────────────────
+  describe('generateDecadeGrid', () => {
+    it('generates exactly 10 years', () => {
+      expect(ChronicaCalendarUtils.generateDecadeGrid(2024).length).toBe(10);
+    });
+    it('starts at the beginning of the decade', () => {
+      expect(ChronicaCalendarUtils.generateDecadeGrid(2024)[0]).toBe(2020);
+    });
+    it('ends at the last year of the decade', () => {
+      expect(ChronicaCalendarUtils.generateDecadeGrid(2024)[9]).toBe(2029);
+    });
+    it('works for an exact decade boundary', () => {
+      expect(ChronicaCalendarUtils.generateDecadeGrid(2030)[0]).toBe(2030);
+    });
+  });
+
+  // ─── updateYearRange ───────────────────────────────────────────────────────
+  describe('updateYearRange', () => {
+    it('generates 21 years (±10 around center)', () => {
+      const range = ChronicaCalendarUtils.updateYearRange(2024);
+      expect(range.length).toBe(21);
+    });
+    it('starts 10 years before the center year', () => {
+      expect(ChronicaCalendarUtils.updateYearRange(2024)[0]).toBe(2014);
+    });
+    it('ends 10 years after the center year', () => {
+      const range = ChronicaCalendarUtils.updateYearRange(2024);
+      expect(range[range.length - 1]).toBe(2034);
+    });
+    it('contains the center year', () => {
+      expect(ChronicaCalendarUtils.updateYearRange(2024)).toContain(2024);
+    });
+  });
+
+  // ─── isDateDisabled ────────────────────────────────────────────────────────
+  describe('isDateDisabled', () => {
+    it('returns false with no constraints', () => {
+      expect(ChronicaCalendarUtils.isDateDisabled(d(2024, 4, 15), {})).toBeFalse();
+    });
+    it('returns true when date is before minDate', () => {
+      expect(ChronicaCalendarUtils.isDateDisabled(d(2024, 4, 9), { minDate: d(2024, 4, 10) })).toBeTrue();
+    });
+    it('returns false when date equals minDate', () => {
+      expect(ChronicaCalendarUtils.isDateDisabled(d(2024, 4, 10), { minDate: d(2024, 4, 10) })).toBeFalse();
+    });
+    it('returns true when date is after maxDate', () => {
+      expect(ChronicaCalendarUtils.isDateDisabled(d(2024, 4, 21), { maxDate: d(2024, 4, 20) })).toBeTrue();
+    });
+    it('returns false when date equals maxDate', () => {
+      expect(ChronicaCalendarUtils.isDateDisabled(d(2024, 4, 20), { maxDate: d(2024, 4, 20) })).toBeFalse();
+    });
+    it('returns true when date is in disabledDates', () => {
+      expect(ChronicaCalendarUtils.isDateDisabled(d(2024, 4, 15), { disabledDates: [d(2024, 4, 15)] })).toBeTrue();
+    });
+    it('returns false when date is not in disabledDates', () => {
+      expect(ChronicaCalendarUtils.isDateDisabled(d(2024, 4, 16), { disabledDates: [d(2024, 4, 15)] })).toBeFalse();
+    });
+    it('ignores time when comparing against minDate', () => {
+      const minDate = new Date(2024, 4, 10, 23, 59, 59);
+      expect(ChronicaCalendarUtils.isDateDisabled(d(2024, 4, 10), { minDate })).toBeFalse();
+    });
+  });
+
+  // ─── generateCalendarMonth ─────────────────────────────────────────────────
+  describe('generateCalendarMonth', () => {
+    it('returns correct month and year', () => {
+      const month = ChronicaCalendarUtils.generateCalendarMonth(2024, 4);
+      expect(month.month).toBe(4);
+      expect(month.year).toBe(2024);
+    });
+    it('generates between 4 and 6 weeks', () => {
+      const month = ChronicaCalendarUtils.generateCalendarMonth(2024, 4);
+      expect(month.weeks.length).toBeGreaterThanOrEqual(4);
+      expect(month.weeks.length).toBeLessThanOrEqual(6);
+    });
+    it('each week has exactly 7 cells', () => {
+      const month = ChronicaCalendarUtils.generateCalendarMonth(2024, 4);
+      month.weeks.forEach((week) => expect(week.length).toBe(7));
+    });
+    it('marks today as isToday', () => {
+      const now = new Date();
+      const month = ChronicaCalendarUtils.generateCalendarMonth(now.getFullYear(), now.getMonth());
+      const todayCell = month.dates.find((c) => ChronicaCalendarUtils.isSameDate(c.date, now));
+      expect(todayCell?.isToday).toBeTrue();
+    });
+    it('cells outside current month have inCurrentMonth = false', () => {
+      const month = ChronicaCalendarUtils.generateCalendarMonth(2024, 4);
+      month.dates
+        .filter((c) => !c.inCurrentMonth)
+        .forEach((c) => expect(c.date.getMonth()).not.toBe(4));
+    });
+    it('uses en-US displayName by default', () => {
+      const month = ChronicaCalendarUtils.generateCalendarMonth(2024, 4);
+      expect(month.displayName).toBe('May');
+    });
+    it('respects firstDayOfWeek = 1 (Monday)', () => {
+      const month = ChronicaCalendarUtils.generateCalendarMonth(2024, 4, { firstDayOfWeek: 1 });
+      month.weeks.forEach((week) => expect(week[0].date.getDay()).toBe(1));
+    });
+    it('respects firstDayOfWeek = 0 (Sunday)', () => {
+      const month = ChronicaCalendarUtils.generateCalendarMonth(2024, 4, { firstDayOfWeek: 0 });
+      month.weeks.forEach((week) => expect(week[0].date.getDay()).toBe(0));
+    });
+    it('disables dates before minDate', () => {
+      const minDate = d(2024, 4, 10);
+      const month = ChronicaCalendarUtils.generateCalendarMonth(2024, 4, { minDate });
+      const day9 = month.dates.find(
+        (c) => c.inCurrentMonth && c.date.getDate() === 9
+      );
+      expect(day9?.disabled).toBeTrue();
+    });
+    it('all dates in month array are unique', () => {
+      const month = ChronicaCalendarUtils.generateCalendarMonth(2024, 4);
+      const timestamps = month.dates.map((c) => c.date.getTime());
+      const unique = new Set(timestamps);
+      expect(unique.size).toBe(timestamps.length);
+    });
+  });
+});

--- a/projects/chronica/src/lib/utils/calendar.utils.ts
+++ b/projects/chronica/src/lib/utils/calendar.utils.ts
@@ -107,7 +107,7 @@ export class ChronicaCalendarUtils {
       const week: ChronicaDate[] = [];
 
       for (let i = 0; i < 7; i++) {
-        const calendarDate = this.createCalendarDate(currentDate, year, month, config);
+        const calendarDate = this.createCalendarDate(currentDate, month, year, config);
         week.push(calendarDate);
         dates.push(calendarDate);
         currentDate.setDate(currentDate.getDate() + 1);

--- a/projects/chronica/src/lib/utils/time.utils.spec.ts
+++ b/projects/chronica/src/lib/utils/time.utils.spec.ts
@@ -1,0 +1,240 @@
+import { ChronicaTimeUtils } from './time.utils';
+
+describe('ChronicaTimeUtils', () => {
+  // ─── to12Hour ──────────────────────────────────────────────────────────────
+  describe('to12Hour', () => {
+    it('converts 0 (midnight) to 12 AM', () => {
+      expect(ChronicaTimeUtils.to12Hour(0)).toEqual({ hours: 12, period: 'AM' });
+    });
+    it('converts 1 to 1 AM', () => {
+      expect(ChronicaTimeUtils.to12Hour(1)).toEqual({ hours: 1, period: 'AM' });
+    });
+    it('converts 11 to 11 AM', () => {
+      expect(ChronicaTimeUtils.to12Hour(11)).toEqual({ hours: 11, period: 'AM' });
+    });
+    it('converts 12 (noon) to 12 PM', () => {
+      expect(ChronicaTimeUtils.to12Hour(12)).toEqual({ hours: 12, period: 'PM' });
+    });
+    it('converts 13 to 1 PM', () => {
+      expect(ChronicaTimeUtils.to12Hour(13)).toEqual({ hours: 1, period: 'PM' });
+    });
+    it('converts 23 to 11 PM', () => {
+      expect(ChronicaTimeUtils.to12Hour(23)).toEqual({ hours: 11, period: 'PM' });
+    });
+  });
+
+  // ─── to24Hour ──────────────────────────────────────────────────────────────
+  describe('to24Hour', () => {
+    it('converts 12 AM to 0 (midnight)', () => {
+      expect(ChronicaTimeUtils.to24Hour(12, 'AM')).toBe(0);
+    });
+    it('converts 1 AM to 1', () => {
+      expect(ChronicaTimeUtils.to24Hour(1, 'AM')).toBe(1);
+    });
+    it('converts 11 AM to 11', () => {
+      expect(ChronicaTimeUtils.to24Hour(11, 'AM')).toBe(11);
+    });
+    it('converts 12 PM to 12 (noon)', () => {
+      expect(ChronicaTimeUtils.to24Hour(12, 'PM')).toBe(12);
+    });
+    it('converts 1 PM to 13', () => {
+      expect(ChronicaTimeUtils.to24Hour(1, 'PM')).toBe(13);
+    });
+    it('converts 11 PM to 23', () => {
+      expect(ChronicaTimeUtils.to24Hour(11, 'PM')).toBe(23);
+    });
+    it('is the inverse of to12Hour for all 24 hours', () => {
+      for (let h = 0; h < 24; h++) {
+        const { hours, period } = ChronicaTimeUtils.to12Hour(h);
+        expect(ChronicaTimeUtils.to24Hour(hours, period)).withContext(`hour ${h}`).toBe(h);
+      }
+    });
+  });
+
+  // ─── formatTime ────────────────────────────────────────────────────────────
+  describe('formatTime', () => {
+    it('formats 24h HH:mm without seconds', () => {
+      expect(ChronicaTimeUtils.formatTime({ hours: 9, minutes: 5 })).toBe('09:05');
+    });
+    it('formats 24h HH:mm:ss with seconds', () => {
+      expect(ChronicaTimeUtils.formatTime({ hours: 14, minutes: 30, seconds: 45 })).toBe('14:30:45');
+    });
+    it('pads single-digit hours and minutes', () => {
+      expect(ChronicaTimeUtils.formatTime({ hours: 0, minutes: 0 })).toBe('00:00');
+    });
+    it('formats 12h without seconds', () => {
+      expect(ChronicaTimeUtils.formatTime({ hours: 9, minutes: 5, period: 'AM' }, '12h')).toBe('09:05 AM');
+    });
+    it('formats 12h noon', () => {
+      expect(ChronicaTimeUtils.formatTime({ hours: 12, minutes: 0, period: 'PM' }, '12h')).toBe('12:00 PM');
+    });
+    it('formats 12h with seconds', () => {
+      expect(ChronicaTimeUtils.formatTime({ hours: 3, minutes: 5, seconds: 7, period: 'AM' }, '12h')).toBe('03:05:07 AM');
+    });
+    it('falls back to 24h format when period is absent in 12h mode', () => {
+      const result = ChronicaTimeUtils.formatTime({ hours: 15, minutes: 30 }, '12h');
+      expect(result).toBe('15:30');
+    });
+  });
+
+  // ─── parseTime ─────────────────────────────────────────────────────────────
+  describe('parseTime', () => {
+    it('parses a valid 24h time', () => {
+      const result = ChronicaTimeUtils.parseTime('14:30');
+      expect(result).not.toBeNull();
+      expect(result?.hours).toBe(14);
+      expect(result?.minutes).toBe(30);
+    });
+    it('parses 24h time with seconds', () => {
+      const result = ChronicaTimeUtils.parseTime('14:30:45');
+      expect(result?.seconds).toBe(45);
+    });
+    it('parses a valid 12h time (PM)', () => {
+      const result = ChronicaTimeUtils.parseTime('2:30 PM', '12h');
+      expect(result?.hours).toBe(14);
+      expect(result?.minutes).toBe(30);
+    });
+    it('parses a valid 12h time (AM)', () => {
+      const result = ChronicaTimeUtils.parseTime('12:00 AM', '12h');
+      expect(result?.hours).toBe(0);
+    });
+    it('returns null for an empty string', () => {
+      expect(ChronicaTimeUtils.parseTime('')).toBeNull();
+    });
+    it('returns null for hours > 23 in 24h', () => {
+      expect(ChronicaTimeUtils.parseTime('25:00')).toBeNull();
+    });
+    it('returns null for minutes >= 60', () => {
+      expect(ChronicaTimeUtils.parseTime('12:60')).toBeNull();
+    });
+    it('returns null for invalid seconds', () => {
+      expect(ChronicaTimeUtils.parseTime('12:00:60')).toBeNull();
+    });
+    it('returns null for malformed string', () => {
+      expect(ChronicaTimeUtils.parseTime('not-a-time')).toBeNull();
+    });
+    it('trims leading/trailing whitespace', () => {
+      const result = ChronicaTimeUtils.parseTime('  09:05  ');
+      expect(result?.hours).toBe(9);
+    });
+  });
+
+  // ─── getCurrentTime ────────────────────────────────────────────────────────
+  describe('getCurrentTime', () => {
+    it('returns current hours and minutes', () => {
+      const before = new Date();
+      const time = ChronicaTimeUtils.getCurrentTime();
+      const after = new Date();
+      expect(time.hours).toBeGreaterThanOrEqual(before.getHours());
+      expect(time.hours).toBeLessThanOrEqual(after.getHours());
+      expect(time.minutes).toBeDefined();
+    });
+    it('excludes seconds by default', () => {
+      expect(ChronicaTimeUtils.getCurrentTime().seconds).toBeUndefined();
+    });
+    it('includes seconds when flag is true', () => {
+      const time = ChronicaTimeUtils.getCurrentTime(true);
+      expect(time.seconds).toBeDefined();
+      expect(time.seconds!).toBeGreaterThanOrEqual(0);
+      expect(time.seconds!).toBeLessThan(60);
+    });
+  });
+
+  // ─── timeToDate ────────────────────────────────────────────────────────────
+  describe('timeToDate', () => {
+    it('sets hours and minutes correctly', () => {
+      const result = ChronicaTimeUtils.timeToDate({ hours: 14, minutes: 30 });
+      expect(result.getHours()).toBe(14);
+      expect(result.getMinutes()).toBe(30);
+      expect(result.getSeconds()).toBe(0);
+    });
+    it('sets seconds when provided', () => {
+      const result = ChronicaTimeUtils.timeToDate({ hours: 10, minutes: 0, seconds: 45 });
+      expect(result.getSeconds()).toBe(45);
+    });
+    it('preserves date from baseDate', () => {
+      const base = new Date(2024, 4, 15);
+      const result = ChronicaTimeUtils.timeToDate({ hours: 10, minutes: 0 }, base);
+      expect(result.getFullYear()).toBe(2024);
+      expect(result.getMonth()).toBe(4);
+      expect(result.getDate()).toBe(15);
+    });
+    it('does not mutate baseDate', () => {
+      const base = new Date(2024, 4, 15, 9, 0);
+      ChronicaTimeUtils.timeToDate({ hours: 14, minutes: 0 }, base);
+      expect(base.getHours()).toBe(9);
+    });
+    it('clears milliseconds', () => {
+      const result = ChronicaTimeUtils.timeToDate({ hours: 10, minutes: 0 });
+      expect(result.getMilliseconds()).toBe(0);
+    });
+  });
+
+  // ─── dateToTime ────────────────────────────────────────────────────────────
+  describe('dateToTime', () => {
+    it('extracts hours and minutes from a date', () => {
+      const date = new Date(2024, 4, 15, 14, 30, 45);
+      const time = ChronicaTimeUtils.dateToTime(date);
+      expect(time.hours).toBe(14);
+      expect(time.minutes).toBe(30);
+    });
+    it('excludes seconds by default', () => {
+      const time = ChronicaTimeUtils.dateToTime(new Date(2024, 4, 15, 14, 30, 45));
+      expect(time.seconds).toBeUndefined();
+    });
+    it('includes seconds when flag is true', () => {
+      const time = ChronicaTimeUtils.dateToTime(new Date(2024, 4, 15, 14, 30, 45), true);
+      expect(time.seconds).toBe(45);
+    });
+  });
+
+  // ─── compareTime ───────────────────────────────────────────────────────────
+  describe('compareTime', () => {
+    it('returns 0 for equal times', () => {
+      const t = { hours: 10, minutes: 30 };
+      expect(ChronicaTimeUtils.compareTime(t, t)).toBe(0);
+    });
+    it('returns negative when first time is earlier', () => {
+      expect(ChronicaTimeUtils.compareTime({ hours: 9, minutes: 0 }, { hours: 10, minutes: 0 })).toBeLessThan(0);
+    });
+    it('returns positive when first time is later', () => {
+      expect(ChronicaTimeUtils.compareTime({ hours: 11, minutes: 0 }, { hours: 10, minutes: 0 })).toBeGreaterThan(0);
+    });
+    it('compares minutes correctly', () => {
+      expect(ChronicaTimeUtils.compareTime({ hours: 10, minutes: 29 }, { hours: 10, minutes: 30 })).toBeLessThan(0);
+    });
+  });
+
+  // ─── isTimeInRange ─────────────────────────────────────────────────────────
+  describe('isTimeInRange', () => {
+    const range = {
+      startTime: { hours: 9, minutes: 0 },
+      endTime: { hours: 17, minutes: 0 },
+    };
+
+    it('returns true for a time in the middle of the range', () => {
+      expect(ChronicaTimeUtils.isTimeInRange({ hours: 12, minutes: 0 }, range)).toBeTrue();
+    });
+    it('returns true at the start boundary', () => {
+      expect(ChronicaTimeUtils.isTimeInRange({ hours: 9, minutes: 0 }, range)).toBeTrue();
+    });
+    it('returns true at the end boundary', () => {
+      expect(ChronicaTimeUtils.isTimeInRange({ hours: 17, minutes: 0 }, range)).toBeTrue();
+    });
+    it('returns false when time is before the range', () => {
+      expect(ChronicaTimeUtils.isTimeInRange({ hours: 8, minutes: 59 }, range)).toBeFalse();
+    });
+    it('returns false when time is after the range', () => {
+      expect(ChronicaTimeUtils.isTimeInRange({ hours: 17, minutes: 1 }, range)).toBeFalse();
+    });
+    it('returns true when startTime is null', () => {
+      expect(ChronicaTimeUtils.isTimeInRange({ hours: 5, minutes: 0 }, { startTime: null, endTime: { hours: 17, minutes: 0 } })).toBeTrue();
+    });
+    it('returns true when endTime is null', () => {
+      expect(ChronicaTimeUtils.isTimeInRange({ hours: 20, minutes: 0 }, { startTime: { hours: 9, minutes: 0 }, endTime: null })).toBeTrue();
+    });
+    it('returns true when both startTime and endTime are null', () => {
+      expect(ChronicaTimeUtils.isTimeInRange({ hours: 12, minutes: 0 }, { startTime: null, endTime: null })).toBeTrue();
+    });
+  });
+});

--- a/projects/chronica/tsconfig.json
+++ b/projects/chronica/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "../../out-tsc/ide",
+    "ignoreDeprecations": "6.0",
+    "types": ["jasmine"]
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
P1-6: Unit Test Suite

calendar.utils.spec.ts — 50+ tests covering all static utility methods
time.utils.spec.ts — 40+ tests covering all time utility methods
datepicker.component.spec.ts — component, CVA, locale, helpers, outputs, form integration
inline-calendar.component.spec.ts — component, CVA, locale, navigation, view cycling, form integration
Bonus fix: calendar.utils.ts — corrected swapped year/month args in createCalendarDate (was causing inCurrentMonth to always be false)